### PR TITLE
Fix capitalization in docs and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ rpi-mqtt-monitor-v2 --uninstall
 ```
 usage: rpi-mqtt-monitor-v2 [-h] [-H] [-d] [-s] [-v] [-u] [-w] [--uninstall]
 
-Monitor CPU load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.
+Monitor CPU Load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.
 
 options:
   -h, --help       show this help message and exit

--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -919,7 +919,7 @@ def bulk_publish_to_mqtt(monitored_values):
 def parse_arguments():
     parser = argparse.ArgumentParser(
         prog='rpi-mqtt-monitor-v2',
-        description='Monitor CPU load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.'
+        description='Monitor CPU Load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.'
     )
     parser.add_argument('-H', '--hass_api', action='store_true',  help='send readings via Home Assistant API (not via MQTT)', default=False)
     parser.add_argument('-d', '--display',  action='store_true',  help='display values on screen', default=False)

--- a/src/translations.ini
+++ b/src/translations.ini
@@ -1,5 +1,5 @@
 [en]
-cpu_load = CPU load
+cpu_load = CPU Load
 cpu_temperature = CPU Temperature
 disk_usage = Disk Usage
 cpu_voltage = CPU Voltage
@@ -24,8 +24,8 @@ used_space = Used Space
 voltage = Voltage
 update = update
 external_sensors = External Sensors
-data_received = Data received
-data_sent = Data sent
+data_received = Data Received
+data_sent = Data Sent
 
 [bg]
 cpu_load = CPU натоварване
@@ -53,8 +53,8 @@ used_space = Използвано пространство
 voltage = Напрежение
 update = Update
 external_sensors = Външни сензори
-data_received = Data received
-data_sent = Data sent
+data_received = Data Received
+data_sent = Data Sent
 
 [de]
 cpu_load = CPU Auslastung
@@ -82,8 +82,8 @@ used_space = belegter Speicherplatz
 voltage = Spannung
 update = Update
 external_sensors = Externe Sensoren
-data_received = Data received
-data_sent = Data sent
+data_received = Data Received
+data_sent = Data Sent
 
 [fr]
 cpu_load = Charge CPU


### PR DESCRIPTION
## Summary
- capitalize CPU Load, Data Received, and Data Sent strings
- update CLI description to use new capitalization
- adjust README example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522da90908832d880e703fb4c918ab