### PR TITLE
Add interactive update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to track your Raspberry Pi or Ubuntu computer system health and 
 * Automated Installation and Configuration: You can install it and schedule it with a service or cron job with just one command from shell
 * Easy Removal, just run rpi-mqtt-monitor-v2 --uninstall
 * Configurable: You can select what is monitored and how the message(s) are sent (separately or as one csv message)
-* Easy update: You can update the script by calling it with command line "rpi-mqtt-monitor-v2 --update" or via Home Assistant UI
+* Easy update: Run `rpi-mqtt-monitor-v2 --version` to check for updates and install them, or call `rpi-mqtt-monitor-v2 --update` directly or via Home Assistant UI
 * Support multiple languages: English, German and Bulgarian
 
 ## Table of Contents
@@ -85,7 +85,7 @@ options:
   -H, --hass_api   send readings via Home Assistant API (not via MQTT)
   -d, --display    display values on screen
   -s, --service    run script as a service, sleep interval is configurable in config.py
-  -v, --version    display installed version and exit
+  -v, --version    show installed and latest version, optionally update
   -u, --update     update script and config then exit
   -w, --hass_wake  display Home assistant wake on lan configuration
   --uninstall      uninstall rpi-mqtt-monitor-v2 and remove all related files

--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -943,6 +943,9 @@ def parse_arguments():
         logger.info("Latest version: %s", latest_version)
         if installed_version != latest_version:
             logger.info("Update available")
+            response = input("Update to %s? [y/N]: " % latest_version)
+            if response.lower() in ["y", "yes"]:
+                update.do_update(script_dir, latest_version, True)
         else:
             logger.info("No update available")
         exit()

--- a/src/update.py
+++ b/src/update.py
@@ -73,7 +73,16 @@ def display_config_differences(current_config, example_config, display=True):
 
 
 def check_git_version_remote(script_dir):
+    """Return the newest tag from the remote repository."""
     try:
+        subprocess.run(
+            ["/usr/bin/git", "-C", script_dir, "fetch", "--tags"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
         result = subprocess.run(
             ["/usr/bin/git", "-C", script_dir, "tag", "--sort=-v:refname"],
             check=True,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -40,9 +40,15 @@ class TestFunctions(unittest.TestCase):
         with mock.patch('subprocess.run', return_value=mock_completed) as m:
             version = update.check_git_version_remote('/tmp')
             self.assertEqual(version, 'v1.0')
-            m.assert_called_with([
-                '/usr/bin/git', '-C', '/tmp', 'tag', '--sort=-v:refname'
-            ], check=True, stdout=mock.ANY, stderr=mock.ANY, text=True)
+            expected_calls = [
+                mock.call([
+                    '/usr/bin/git', '-C', '/tmp', 'fetch', '--tags'
+                ], check=True, stdout=mock.ANY, stderr=mock.ANY, text=True),
+                mock.call([
+                    '/usr/bin/git', '-C', '/tmp', 'tag', '--sort=-v:refname'
+                ], check=True, stdout=mock.ANY, stderr=mock.ANY, text=True)
+            ]
+            m.assert_has_calls(expected_calls)
 
     def test_install_requirements_error(self):
         with mock.patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'cmd')):


### PR DESCRIPTION
## Summary
- refresh remote tags when checking git version
- prompt to update if `--version` detects a newer release
- document update prompt in CLI help
- adjust unit tests for new git fetch behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525da4146c832d91bb2ad196a1011b