### PR TITLE
Rename to rpi-mqtt-monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-rpi-mqtt-monitor-v2/
+rpi-mqtt-monitor/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Raspberry Pi MQTT Monitor V2
+# Raspberry Pi MQTT Monitor
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2/releases)
-[![GitHub repo size](https://img.shields.io/github/repo-size/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2)
-[![GitHub issues](https://img.shields.io/github/issues/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2/issues)
-[![GitHub closed issues](https://img.shields.io/github/issues-closed/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2/issues?q=is%3Aissue+is%3Aclosed)
-[![GitHub language count](https://img.shields.io/github/languages/count/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2)
-[![GitHub top language](https://img.shields.io/github/languages/top/danmrossi/rpi-mqtt-monitor-v2)](https://github.com/danmrossi/rpi-mqtt-monitor-v2)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor/releases)
+[![GitHub repo size](https://img.shields.io/github/repo-size/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor)
+[![GitHub issues](https://img.shields.io/github/issues/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor/issues)
+[![GitHub closed issues](https://img.shields.io/github/issues-closed/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor/issues?q=is%3Aissue+is%3Aclosed)
+[![GitHub language count](https://img.shields.io/github/languages/count/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor)
+[![GitHub top language](https://img.shields.io/github/languages/top/hjelev/rpi-mqtt-monitor)](https://github.com/hjelev/rpi-mqtt-monitor)
 
 <p align="center">
   <img src="./images/rpi-mqtt-monitor-2-min.png" alt="Raspberry Pi MQTT Monitor" />
@@ -18,9 +18,9 @@ The easiest way to track your Raspberry Pi or Ubuntu computer system health and 
 * Remotely Restart / Shutdown your system and control your monitors
 * Automatic HASS Configuration: Supports discovery messages, so no manual configuration in [Home Assistant](https://www.home-assistant.io/) configuration.yaml is needed
 * Automated Installation and Configuration: You can install it and schedule it with a service or cron job with just one command from shell
-* Easy Removal, just run rpi-mqtt-monitor-v2 --uninstall
+* Easy Removal, just run rpi-mqtt-monitor --uninstall
 * Configurable: You can select what is monitored and how the message(s) are sent (separately or as one csv message)
-* Easy update: Run `rpi-mqtt-monitor-v2 --version` to check for updates and install them, or call `rpi-mqtt-monitor-v2 --update` directly or via Home Assistant UI
+* Easy update: Run `rpi-mqtt-monitor --version` to check for updates and install them, or call `rpi-mqtt-monitor --update` directly or via Home Assistant UI
 * Support multiple languages: English, German and Bulgarian
 
 ## Table of Contents
@@ -30,11 +30,11 @@ The easiest way to track your Raspberry Pi or Ubuntu computer system health and 
   - [Automated](#automated)
   - [Automated installation preview](#automated-installation-preview)
   - [Manual](#manual)
-  - [How to update](https://github.com/danmrossi/rpi-mqtt-monitor-v2/wiki/How-to-update)
-- [Configuration](https://github.com/danmrossi/rpi-mqtt-monitor-v2/wiki/Configuration)
-  - [External Sensors](https://github.com/danmrossi/rpi-mqtt-monitor-v2/wiki/External-Sensors)
-- [Schedule Raspberry Pi MQTT Monitor execution as a service](https://github.com/danmrossi/rpi-mqtt-monitor-v2/wiki/Manual-Installation#schedule-raspberry-pi-mqtt-monitor-execution-as-a-service)
-- [Schedule Raspberry Pi MQTT Monitor execution with a cron](https://github.com/danmrossi/rpi-mqtt-monitor-v2/wiki/Manual-Installation#schedule-raspberry-pi-mqtt-monitor-execution-with-a-cron)
+  - [How to update](https://github.com/hjelev/rpi-mqtt-monitor/wiki/How-to-update)
+- [Configuration](https://github.com/hjelev/rpi-mqtt-monitor/wiki/Configuration)
+  - [External Sensors](https://github.com/hjelev/rpi-mqtt-monitor/wiki/External-Sensors)
+- [Schedule Raspberry Pi MQTT Monitor execution as a service](https://github.com/hjelev/rpi-mqtt-monitor/wiki/Manual-Installation#schedule-raspberry-pi-mqtt-monitor-execution-as-a-service)
+- [Schedule Raspberry Pi MQTT Monitor execution with a cron](https://github.com/hjelev/rpi-mqtt-monitor/wiki/Manual-Installation#schedule-raspberry-pi-mqtt-monitor-execution-with-a-cron)
 - [Home Assistant Integration](#home-assistant-integration)
 - [To Do](#to-do)
 - [Feature request](#feature-request)
@@ -47,10 +47,10 @@ The easiest way to track your Raspberry Pi or Ubuntu computer system health and 
 Run this command to use the automated installation:
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/danmrossi/rpi-mqtt-monitor-v2/master/remote_install.sh)
+bash <(curl -s https://raw.githubusercontent.com/hjelev/rpi-mqtt-monitor/master/remote_install.sh)
 ```
 
-Raspberry Pi MQTT Monitor will be installed in the location where the installer is called, inside a folder named rpi-mqtt-monitor-v2.
+Raspberry Pi MQTT Monitor will be installed in the location where the installer is called, inside a folder named rpi-mqtt-monitor.
 
 The auto-installer needs the following software below and will install it if its not found:
 
@@ -70,13 +70,13 @@ It is recommended to run the script as a service, this way you can use the resta
 To uninstall Raspberry Pi MQTT Monitor, run the following command:
 
 ```bash
-rpi-mqtt-monitor-v2 --uninstall
+rpi-mqtt-monitor --uninstall
 ```
 
 ## CLI arguments
 
 ```
-usage: rpi-mqtt-monitor-v2 [-h] [-H] [-d] [-s] [-v] [-u] [-w] [--uninstall]
+usage: rpi-mqtt-monitor [-h] [-H] [-d] [-s] [-v] [-u] [-w] [--uninstall]
 
 Monitor CPU Load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.
 
@@ -88,7 +88,7 @@ options:
   -v, --version    show installed and latest version, optionally update
   -u, --update     update script and config then exit
   -w, --hass_wake  display Home assistant wake on lan configuration
-  --uninstall      uninstall rpi-mqtt-monitor-v2 and remove all related files
+  --uninstall      uninstall rpi-mqtt-monitor and remove all related files
 
 ```
 
@@ -96,7 +96,7 @@ options:
 
 If you are using discovery_messages, then this step is not required as a new MQTT device will be automatically created in Home Assistant and all you need to do is add it to a dashboard.
 
-Use '''rpi-mqtt-monitor-v2 --hass_wake''' to display the configuration for Home Assistant wake on lan switch.
+Use '''rpi-mqtt-monitor --hass_wake''' to display the configuration for Home Assistant wake on lan switch.
 
 ## Feature request
 

--- a/install.sh
+++ b/install.sh
@@ -222,10 +222,10 @@ set_cron(){
 set_service(){
   printm "Setting systemd service"
 
-  if [ -f /etc/systemd/system/rpi-mqtt-monitor-v2.service ]; then
+  if [ -f /etc/systemd/system/rpi-mqtt-monitor.service ]; then
     read -p "Service file already exists. Do you want to remove it? (y/n) " yn
     case $yn in
-        [Yy]* ) sudo rm /etc/systemd/system/rpi-mqtt-monitor-v2.service;;
+        [Yy]* ) sudo rm /etc/systemd/system/rpi-mqtt-monitor.service;;
         [Nn]* ) return;;
         * ) echo "Please answer y for yes or n for no.";;
     esac
@@ -239,23 +239,23 @@ set_service(){
   cwd=$(pwd)
   user=$(whoami)
   exec_start="${python} ${cwd}/src/rpi-cpu2mqtt.py --service${hass_api}"
-  print_green "+ Copy rpi-mqtt-monitor-v2.service to /etc/systemd/system/"
-  sudo cp ${cwd}/rpi-mqtt-monitor-v2.service /etc/systemd/system/
-  sudo sed -i "s|WorkingDirectory=.*|WorkingDirectory=${cwd}|" /etc/systemd/system/rpi-mqtt-monitor-v2.service
-  sudo sed -i "s|User=YOUR_USER|User=root|" /etc/systemd/system/rpi-mqtt-monitor-v2.service
-  sudo sed -i "s|ExecStart=.*|ExecStart=${exec_start}|" /etc/systemd/system/rpi-mqtt-monitor-v2.service
+  print_green "+ Copy rpi-mqtt-monitor.service to /etc/systemd/system/"
+  sudo cp ${cwd}/rpi-mqtt-monitor.service /etc/systemd/system/
+  sudo sed -i "s|WorkingDirectory=.*|WorkingDirectory=${cwd}|" /etc/systemd/system/rpi-mqtt-monitor.service
+  sudo sed -i "s|User=YOUR_USER|User=root|" /etc/systemd/system/rpi-mqtt-monitor.service
+  sudo sed -i "s|ExecStart=.*|ExecStart=${exec_start}|" /etc/systemd/system/rpi-mqtt-monitor.service
   home_dir=$(eval echo ~$user)
-  sudo sed -i "s|Environment=\"HOME=/home/username\"|Environment=\"HOME=${home_dir}\"|" /etc/systemd/system/rpi-mqtt-monitor-v2.service
+  sudo sed -i "s|Environment=\"HOME=/home/username\"|Environment=\"HOME=${home_dir}\"|" /etc/systemd/system/rpi-mqtt-monitor.service
   sudo systemctl daemon-reload
-  sudo systemctl enable rpi-mqtt-monitor-v2.service
-  sudo systemctl start rpi-mqtt-monitor-v2.service
-  sudo service rpi-mqtt-monitor-v2 restart
+  sudo systemctl enable rpi-mqtt-monitor.service
+  sudo systemctl start rpi-mqtt-monitor.service
+  sudo service rpi-mqtt-monitor restart
   print_green "+ Service is enabled and started"
   git config --global --add safe.directory ${cwd}
 }
 
 create_shortcut(){
-  printm "Creating shortcut rpi-mqtt-monitor-v2"
+  printm "Creating shortcut rpi-mqtt-monitor"
   cwd=$(pwd)
 
   # Ensure /usr/local/bin exists
@@ -264,9 +264,9 @@ create_shortcut(){
     print_green "/usr/local/bin created."
   fi
 
-  echo "${python} ${cwd}/src/rpi-cpu2mqtt.py \$@" > rpi-mqtt-monitor-v2
-  sudo mv rpi-mqtt-monitor-v2 /usr/local/bin/
-  sudo chmod +x /usr/local/bin/rpi-mqtt-monitor-v2
+  echo "${python} ${cwd}/src/rpi-cpu2mqtt.py \$@" > rpi-mqtt-monitor
+  sudo mv rpi-mqtt-monitor /usr/local/bin/
+  sudo chmod +x /usr/local/bin/rpi-mqtt-monitor
 }
 
 main(){
@@ -287,8 +287,8 @@ main(){
   done
   
   printm "Installation is complete."
-  echo "rpi-mqtt-monitor-v2 is now running and sending information to your ${finish_message}."
-  echo "To see all available options run: rpi-mqtt-monitor-v2 -h in the terminal."
+  echo "rpi-mqtt-monitor is now running and sending information to your ${finish_message}."
+  echo "To see all available options run: rpi-mqtt-monitor -h in the terminal."
 }
 
 main

--- a/remote_install.sh
+++ b/remote_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Description: Remote Installation script for rpi-mqtt-monitor-v2
+# Description: Remote Installation script for rpi-mqtt-monitor
 
 printm(){
   length=$(expr length "$1")
@@ -23,10 +23,10 @@ welcome(){
 }
 
 uninstall(){
-  printm "Uninstalling rpi-mqtt-monitor-v2"
+  printm "Uninstalling rpi-mqtt-monitor"
 
   # Ask for confirmation before proceeding
-  read -r -p "Are you sure you want to uninstall rpi-mqtt-monitor-v2? [y/N] " response
+  read -r -p "Are you sure you want to uninstall rpi-mqtt-monitor? [y/N] " response
   if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
     echo "Uninstallation canceled."
     exit
@@ -35,16 +35,16 @@ uninstall(){
   # Get the absolute path of the script
   script_dir=$(dirname "$(realpath "$0")")
 
-  # Remove the rpi-mqtt-monitor-v2 directory if it exists
+  # Remove the rpi-mqtt-monitor directory if it exists
   if [ -d "$script_dir" ]; then
-    if [ "$(realpath rpi-mqtt-monitor-v2)" == "$script_dir" ]; then
+    if [ "$(realpath rpi-mqtt-monitor)" == "$script_dir" ]; then
       # If the script is running from the installation directory, navigate out of it
       cd ..
     fi
     sudo rm -rf "$script_dir"
-    echo "Removed rpi-mqtt-monitor-v2 directory."
+    echo "Removed rpi-mqtt-monitor directory."
   else
-    echo "rpi-mqtt-monitor-v2 directory not found."
+    echo "rpi-mqtt-monitor directory not found."
   fi
   
   # Remove the cron job if it exists
@@ -56,14 +56,14 @@ uninstall(){
   fi
 
   # Remove the systemd service if it exists
-  if [ -f /etc/systemd/system/rpi-mqtt-monitor-v2.service ]; then
-    sudo systemctl stop rpi-mqtt-monitor-v2.service
-    sudo systemctl disable rpi-mqtt-monitor-v2.service
-    sudo rm /etc/systemd/system/rpi-mqtt-monitor-v2.service
+  if [ -f /etc/systemd/system/rpi-mqtt-monitor.service ]; then
+    sudo systemctl stop rpi-mqtt-monitor.service
+    sudo systemctl disable rpi-mqtt-monitor.service
+    sudo rm /etc/systemd/system/rpi-mqtt-monitor.service
     sudo systemctl daemon-reload
-    echo "Removed systemd service for rpi-mqtt-monitor-v2."
+    echo "Removed systemd service for rpi-mqtt-monitor."
   else
-    echo "No systemd service found for rpi-mqtt-monitor-v2."
+    echo "No systemd service found for rpi-mqtt-monitor."
   fi
 
   # Optionally remove git if it was installed by this script
@@ -84,9 +84,9 @@ main(){
     sudo apt-get install git  
   fi
 
-  printm "Cloning rpi-mqtt-monitor-v2 git repository"
-  git clone https://github.com/danmrossi/rpi-mqtt-monitor-v2.git
-  cd rpi-mqtt-monitor-v2
+  printm "Cloning rpi-mqtt-monitor git repository"
+  git clone https://github.com/hjelev/rpi-mqtt-monitor.git
+  cd rpi-mqtt-monitor
   git pull
   bash install.sh
 }

--- a/rpi-mqtt-monitor.service
+++ b/rpi-mqtt-monitor.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=RPI MQTT Monitor V2
+Description=RPI MQTT Monitor
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/home/username/git/rpi-mqtt-monitor-v2/rpi_mon_env/bin/python /home/username/git/rpi-mqtt-monitor-v2/src/rpi-cpu2mqtt.py --service
+ExecStart=/home/username/git/rpi-mqtt-monitor/rpi_mon_env/bin/python /home/username/git/rpi-mqtt-monitor/src/rpi-cpu2mqtt.py --service
 Environment="HOME=/home/username"
-WorkingDirectory=/home/username/git/rpi-mqtt-monitor-v2/
+WorkingDirectory=/home/username/git/rpi-mqtt-monitor/
 StandardOutput=inherit
 StandardError=inherit
 Restart=always

--- a/src/config.py.example
+++ b/src/config.py.example
@@ -9,7 +9,7 @@ mqtt_user = "username"
 mqtt_password = "password"
 mqtt_port = "1883"
 mqtt_discovery_prefix = "homeassistant"
-mqtt_topic_prefix = "rpi-MQTT-monitor-v2"
+mqtt_topic_prefix = "rpi-MQTT-monitor"
 mqtt_uns_structure = ""
 
 # Retain flag for published topics

--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# rpi-mqtt-monitor-v2 is a python script to monitor cpu load, temperature, frequency, free space etc.
+# rpi-mqtt-monitor is a python script to monitor cpu load, temperature, frequency, free space etc.
 # on a Raspberry Pi or Ubuntu computer and publish the data to a MQTT server or Home Assistant API.
 
 from __future__ import division
@@ -139,7 +139,7 @@ def check_rpi_power_status():
         return 'Error: ' + str(e)
 
 def check_service_file_exists():
-    service_file_path = "/etc/systemd/system/rpi-mqtt-monitor-v2.service"
+    service_file_path = "/etc/systemd/system/rpi-mqtt-monitor.service"
     return os.path.exists(service_file_path)
 
 
@@ -389,7 +389,7 @@ def check_all_drive_temps():
 
 def print_measured_values(monitored_values):
     remote_version = update.check_git_version_remote(script_dir)
-    output = """:: rpi-mqtt-monitor-v2 :: v {}
+    output = """:: rpi-mqtt-monitor :: v {}
 
 :: Device Information
    Model Name: {}
@@ -455,7 +455,7 @@ def extract_text(html_string):
 
 
 def get_release_notes(version):
-    url = "https://github.com/danmrossi/rpi-mqtt-monitor-v2/releases/tag/" + version
+    url = "https://github.com/hjelev/rpi-mqtt-monitor/releases/tag/" + version
 
     try:
         response = subprocess.run(['curl', '-s', url], capture_output=True)
@@ -477,12 +477,12 @@ def get_release_notes(version):
 def build_device_info():
     return {
         "identifiers": [hostname],
-        "manufacturer": 'github.com/danmrossi',
-        "model": f'RPi MQTT Monitor V2 {config.version}',
+        "manufacturer": 'github.com/hjelev',
+        "model": f'RPi MQTT Monitor {config.version}',
         "name": hostname,
         "sw_version": get_os(),
         "hw_version": f"{check_model_name()} by {get_manufacturer()} IP:{get_network_ip()}",
-        "configuration_url": "https://github.com/danmrossi/rpi-mqtt-monitor-v2",
+        "configuration_url": "https://github.com/hjelev/rpi-mqtt-monitor",
         "connections": [["mac", get_mac_address()]]
     }
 
@@ -547,8 +547,8 @@ def handle_specific_configurations(data, what_config, device):
         data["value_template"] = "{{ {'installed_version': value_json.installed_ver, 'latest_version': value_json.new_ver } | to_json }}"
         data["command_topic"] = config.mqtt_discovery_prefix + "/update/" + hostname + "/command"
         data["payload_install"] = "install"
-        data['release_url'] = "https://github.com/danmrossi/rpi-mqtt-monitor-v2/releases/tag/" + version
-        data['entity_picture'] = "https://raw.githubusercontent.com/danmrossi/rpi-mqtt-monitor-v2/refs/heads/master/images/update_icon.png"
+        data['release_url'] = "https://github.com/hjelev/rpi-mqtt-monitor/releases/tag/" + version
+        data['entity_picture'] = "https://raw.githubusercontent.com/hjelev/rpi-mqtt-monitor/refs/heads/master/images/update_icon.png"
         data['release_summary'] = get_release_notes(version)
     elif what_config == "restart_button":
         add_common_attributes(data, "mdi:restart", get_translation("system_restart"))
@@ -631,7 +631,7 @@ def create_mqtt_client():
 
         # Persistent session + auto-re-subscribe on reconnect
     client = paho.Client(
-        client_id=f"rpi-mqtt-monitor-v2-{hostname}-{int(time.time())}",
+        client_id=f"rpi-mqtt-monitor-{hostname}-{int(time.time())}",
         clean_session=False
     )
     client.username_pw_set(config.mqtt_user, config.mqtt_password)
@@ -918,7 +918,7 @@ def bulk_publish_to_mqtt(monitored_values):
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        prog='rpi-mqtt-monitor-v2',
+        prog='rpi-mqtt-monitor',
         description='Monitor CPU Load, temperature, frequency, free space, etc., and publish the data to an MQTT server or Home Assistant API.'
     )
     parser.add_argument('-H', '--hass_api', action='store_true',  help='send readings via Home Assistant API (not via MQTT)', default=False)
@@ -927,7 +927,7 @@ def parse_arguments():
     parser.add_argument('-v', '--version',  action='store_true',  help='display installed version and exit', default=False)
     parser.add_argument('-u', '--update',   action='store_true',  help='update script and config then exit', default=False)
     parser.add_argument('-w', '--hass_wake', action='store_true', help='display Home assistant wake on lan configuration', default=False)
-    parser.add_argument('--uninstall', action='store_true', help='uninstall rpi-mqtt-monitor-v2 and remove all related files')
+    parser.add_argument('--uninstall', action='store_true', help='uninstall rpi-mqtt-monitor and remove all related files')
     args = parser.parse_args()
 
     if args.update:


### PR DESCRIPTION
## Summary
- rename service and CLI references from `rpi-mqtt-monitor-v2` to `rpi-mqtt-monitor`
- update GitHub URLs to new owner `hjelev`
- adjust installation scripts and service file
- update default config topic prefix

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q --ignore=rpi-mqtt-monitor`

------
https://chatgpt.com/codex/tasks/task_e_6859190dd8d8832daa5bbd7074bbcbf8