### PR TITLE
Add service startup delay

### DIFF
--- a/rpi-mqtt-monitor-v2.service
+++ b/rpi-mqtt-monitor-v2.service
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+ExecStartPre=/bin/sleep 120
 ExecStart=/home/username/git/rpi-mqtt-monitor-v2/rpi_mon_env/bin/python /home/username/git/rpi-mqtt-monitor-v2/src/rpi-cpu2mqtt.py --service
 Environment="HOME=/home/username"
 WorkingDirectory=/home/username/git/rpi-mqtt-monitor-v2/


### PR DESCRIPTION
## Summary
- delay service startup by 120 seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd4dad3c8832db00d6b1f7e4432ee