### PR TITLE
Use git from PATH

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -313,8 +313,8 @@ def check_git_update(script_dir):
 
 def check_git_version(script_dir):
     try:
-        rev = subprocess.run(['/usr/bin/git', '-C', script_dir, 'rev-list', '--tags', '--max-count=1'], stdout=subprocess.PIPE, text=True, check=True).stdout.strip()
-        result = subprocess.run(['/usr/bin/git', '-C', script_dir, 'describe', '--tags', rev], stdout=subprocess.PIPE, text=True, check=True)
+        rev = subprocess.run(['git', '-C', script_dir, 'rev-list', '--tags', '--max-count=1'], stdout=subprocess.PIPE, text=True, check=True).stdout.strip()
+        result = subprocess.run(['git', '-C', script_dir, 'describe', '--tags', rev], stdout=subprocess.PIPE, text=True, check=True)
         git_version = result.stdout.strip()
     except subprocess.CalledProcessError as e:
         logger.error('Error getting git version: %s', e)

--- a/src/update.py
+++ b/src/update.py
@@ -76,7 +76,7 @@ def check_git_version_remote(script_dir):
     """Return the newest tag from the remote repository."""
     try:
         subprocess.run(
-            ["/usr/bin/git", "-C", script_dir, "fetch", "--tags"],
+            ["git", "-C", script_dir, "fetch", "--tags"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -84,7 +84,7 @@ def check_git_version_remote(script_dir):
         )
 
         result = subprocess.run(
-            ["/usr/bin/git", "-C", script_dir, "tag", "--sort=-v:refname"],
+            ["git", "-C", script_dir, "tag", "--sort=-v:refname"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -129,7 +129,7 @@ def do_update(script_dir, version=config.version, git_update=True, config_update
     logger.info("Current version: %s", config.version)
     if git_update:
         logger.info("Updating git repository %s", script_dir)
-        result = subprocess.run(['/usr/bin/git', '-C', script_dir, 'pull'], check=True, text=True, stdout=subprocess.PIPE)
+        result = subprocess.run(['git', '-C', script_dir, 'pull'], check=True, text=True, stdout=subprocess.PIPE)
         logger.info(result.stdout)
         install_requirements(script_dir)
         

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -55,10 +55,10 @@ class TestFunctions(unittest.TestCase):
             self.assertEqual(version, 'v1.0')
             expected_calls = [
                 mock.call([
-                    '/usr/bin/git', '-C', '/tmp', 'fetch', '--tags'
+                    'git', '-C', '/tmp', 'fetch', '--tags'
                 ], check=True, stdout=mock.ANY, stderr=mock.ANY, text=True),
                 mock.call([
-                    '/usr/bin/git', '-C', '/tmp', 'tag', '--sort=-v:refname'
+                    'git', '-C', '/tmp', 'tag', '--sort=-v:refname'
                 ], check=True, stdout=mock.ANY, stderr=mock.ANY, text=True)
             ]
             m.assert_has_calls(expected_calls)


### PR DESCRIPTION
## Summary
- call `git` without a hardcoded path in update utilities
- update tests for the new command path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df111a3ac832dba070d5ea78ebd49