### PR TITLE
Adjust service timeout and reload via installer

### DIFF
--- a/remote_install.sh
+++ b/remote_install.sh
@@ -89,6 +89,10 @@ main(){
   cd rpi-mqtt-monitor-v2
   git pull
   bash install.sh
+  cwd=$(pwd)
+  sudo cp ${cwd}/rpi-mqtt-monitor-v2.service /etc/systemd/system/
+  sudo systemctl daemon-reload
+  sudo systemctl restart rpi-mqtt-monitor-v2.service
 }
 
 # Check for uninstall flag

--- a/rpi-mqtt-monitor-v2.service
+++ b/rpi-mqtt-monitor-v2.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStartPre=/bin/sleep 120
+ExecStartPre=/bin/sleep 10
 ExecStart=/home/username/git/rpi-mqtt-monitor-v2/rpi_mon_env/bin/python /home/username/git/rpi-mqtt-monitor-v2/src/rpi-cpu2mqtt.py --service
 Environment="HOME=/home/username"
 WorkingDirectory=/home/username/git/rpi-mqtt-monitor-v2/


### PR DESCRIPTION
## Summary
- shorten service ExecStartPre to 10 seconds
- ensure remote installer updates the service unit and restarts it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df0f59428832d822314c0f314baee