### PR TITLE
Add Python 3 auto-installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ The auto-installer needs the following software below and will install it if its
 * git
 * python3
 * python3-pip
+* python3-venv
 * paho-mqtt (python module)
 * requests (python module)
 
-Only Python 3 is not automatically installed, the rest of the dependencies should be handled by the auto installation.
+The auto-installer will attempt to install Python 3 and its required packages if they are missing.
 It will also help you configure the host and credentials for the mqtt server in config.py and create the service or cronjob configuration for you.
 It is recommended to run the script as a service, this way you can use the restart, shutdown and display control buttons in Home Assistant.
 

--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 find_python(){
-  if [[ $(python3 --version)  ]]; then 
-    python=$(which python3)
-    pip="python3-pip"
-    pip_run='pip3'
-  else
-    python=$(which python)
-    pip="python-pip"
-    pip_run='pip'
+  if ! command -v python3 >/dev/null 2>&1; then
+    print_yellow "Python 3 not found! Installing python3."
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-pip python3-venv
   fi
 
-  if [[ "$python" == *"python"* ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    python=$(command -v python3)
+    pip_pkg="python3-pip"
+    pip_run='pip3'
     print_green "+ Found: $python"
-
   else
-    print_yellow "Python not found!\n Exiting\n"
+    print_yellow "Python 3 installation failed!\n Exiting\n"
     exit
   fi
 }
@@ -45,9 +43,9 @@ check_and_install_pip(){
   pip_ver=$(${python} -m pip --version 2>&1);
   if [[ "$pip_ver" == *"No"* ]]; then
     echo "- Pip is not installed, installing it."
-    sudo apt install $pip
-    else
-    print_green "+ Found: $pip"
+    sudo apt-get install -y $pip_pkg
+  else
+    print_green "+ Found: $pip_pkg"
   fi
 }
 
@@ -67,11 +65,7 @@ create_venv(){
 
   # Activate the virtual environment
   source rpi_mon_env/bin/activate
-  if [[ $(python3 --version)  ]]; then 
-    python=$(which python3)
-  else
-    python=$(which python)
-  fi
+  python=$(command -v python3)
   print_green "+ Activated virtual environment"
 }
 

--- a/remote_install.sh
+++ b/remote_install.sh
@@ -22,6 +22,14 @@ welcome(){
   fi	
 }
 
+check_python(){
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Python 3 not found. Installing..."
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-pip python3-venv
+  fi
+}
+
 uninstall(){
   printm "Uninstalling rpi-mqtt-monitor-v2"
 
@@ -78,10 +86,11 @@ uninstall(){
 
 main(){
   welcome
-  if [[ $(git --version)  ]]; then 
+  check_python
+  if [[ $(git --version)  ]]; then
     git=$(which git)
   else
-    sudo apt-get install git  
+    sudo apt-get install git
   fi
 
   printm "Cloning rpi-mqtt-monitor-v2 git repository"


### PR DESCRIPTION
## Summary
- auto-install Python 3, pip and venv in installer scripts
- update README dependency section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df032791c832db720e258dc161fe8