### PR TITLE
Fix remote installer service override

### DIFF
--- a/remote_install.sh
+++ b/remote_install.sh
@@ -98,10 +98,6 @@ main(){
   cd rpi-mqtt-monitor-v2
   git pull
   bash install.sh
-  cwd=$(pwd)
-  sudo cp ${cwd}/rpi-mqtt-monitor-v2.service /etc/systemd/system/
-  sudo systemctl daemon-reload
-  sudo systemctl restart rpi-mqtt-monitor-v2.service
 }
 
 # Check for uninstall flag


### PR DESCRIPTION
## Summary
- remove service overwrite step from `remote_install.sh`

This prevents `remote_install.sh` from restoring the template service file after
`install.sh` customizes it, addressing a systemd startup failure.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dfabe7bc4832dae0cea2eb5e19810